### PR TITLE
Revert "Add mount for wasp-cli.json"

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -278,7 +278,6 @@ services:
       - "5550:5550/tcp" # Nano MSG
     volumes:
       - ./data/wasp:/app/waspdb
-      - ./data/wasp-cli/wasp-cli.json:/app/wasp-cli.json
     command:
       - "--logger.level=info"
       - "--inx.address=hornet:9029"

--- a/docker/prepare_docker.sh
+++ b/docker/prepare_docker.sh
@@ -23,9 +23,6 @@ mkdir -p data/grafana
 mkdir -p data/prometheus
 mkdir -p data/dashboard
 mkdir -p data/wasp
-mkdir -p data/wasp-cli
-touch data/wasp-cli/wasp-cli.json
-
 if [[ "$OSTYPE" != "darwin"* ]]; then
   chown -R 65532:65532 data
   chown 65532:65532 peering.json


### PR DESCRIPTION
This reverts commit 74370013d2c4f07c827036cdc4f674d674434bc3.

We removed `wasp-cli` from the wasp container.