### PR TITLE
Removed config parameters for Wasp Dashboard

### DIFF
--- a/stardust/docker-compose.yml
+++ b/stardust/docker-compose.yml
@@ -284,6 +284,7 @@ services:
       - "--registries.dkShares.path=/app/waspdb/dkshares"
       - "--registries.trustedPeers.filePath=/app/waspdb/trusted_peers.json"
       - "--registries.consensusState.path=/app/waspdb/chains/consensus"
+      - "--wal.path=/app/waspdb/wal"
       - "--prometheus.bindAddress=wasp:9312"
       - "--webapi.bindAddress=wasp:9090"
       - "--webapi.auth.scheme=none"

--- a/stardust/docker-compose.yml
+++ b/stardust/docker-compose.yml
@@ -287,8 +287,6 @@ services:
       - "--prometheus.bindAddress=wasp:9312"
       - "--webapi.bindAddress=wasp:9090"
       - "--webapi.auth.scheme=none"
-      - "--dashboard.bindAddress=wasp:7000"
-      - "--dashboard.auth.scheme=basic"
     profiles:
       - wasp
 


### PR DESCRIPTION
This PR removes the 2 config related, no longer existing launch flags for wasp making sure it runs again with docker-compose in the latest versions.