### PR TITLE
Use container_memory_working_set_bytes for memory graphs

### DIFF
--- a/chrysalis/assets/grafana/dashboards/node_dashboard.json
+++ b/chrysalis/assets/grafana/dashboards/node_dashboard.json
@@ -736,7 +736,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "container_memory_usage_bytes{name=\"hornet\"}",
+          "expr": "container_memory_working_set_bytes{name=\"hornet\"}",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1512,7 +1512,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{name=~\".+\"}) by (name)",
+          "expr": "sum(container_memory_working_set_bytes{name=~\".+\"}) by (name)",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"

--- a/legacy/assets/grafana/dashboards/node_dashboard.json
+++ b/legacy/assets/grafana/dashboards/node_dashboard.json
@@ -466,7 +466,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "container_memory_usage_bytes{name=\"hornet\"}",
+          "expr": "container_memory_working_set_bytes{name=\"hornet\"}",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -781,7 +781,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{name=~\".+\"}) by (name)",
+          "expr": "sum(container_memory_working_set_bytes{name=~\".+\"}) by (name)",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"

--- a/stardust/assets/grafana/dashboards/node_dashboard.json
+++ b/stardust/assets/grafana/dashboards/node_dashboard.json
@@ -739,7 +739,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "container_memory_usage_bytes{name=\"hornet\"}",
+          "expr": "container_memory_working_set_bytes{name=\"hornet\"}",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1515,7 +1515,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_usage_bytes{name=~\".+\"}) by (name)",
+          "expr": "sum(container_memory_working_set_bytes{name=~\".+\"}) by (name)",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
replaced container_memory_usage_bytes with container_memory_working_set_bytes because the latter shows the same values as docker stats or top do