### PR TITLE
Add Tangle Bay sources

### DIFF
--- a/stardust/config_defaults.json
+++ b/stardust/config_defaults.json
@@ -124,7 +124,9 @@
       "bindAddress": "0.0.0.0:14626",
       "entryNodes": [
         "/dns/entry-hornet-0.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/K4cHM64KxzYJ5ZB2a9P3stJUHjvQDh4bzhCw49xDowi",
-        "/dns/entry-hornet-1.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/8UbVu5MjRZH2c9fnEdpfPvd7qqDgrVFsNsvc933FuMTm"
+        "/dns/entry-hornet-1.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/8UbVu5MjRZH2c9fnEdpfPvd7qqDgrVFsNsvc933FuMTm",
+        "/dns/entry-0.iota-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC",
+        "/dns/entry-1.iota-mainnet.tanglebay.com/udp/14626/autopeering/CATsx21mFVvQQPXeDineGs9DDeKvoBBQdzcmR6ffCkVA"
       ],
       "entryNodesPreferIPv6": false,
       "runAsEntryNode": false
@@ -152,7 +154,11 @@
       {
         "full": "https://files.stardust-mainnet.iotaledger.net/snapshots/latest-full_snapshot.bin",
         "delta": "https://files.stardust-mainnet.iotaledger.net/snapshots/latest-delta_snapshot.bin"
-      }
+      },
+      {
+        "full": "https://cdn.tanglebay.com/snapshots/iota-mainnet/full_snapshot.bin",
+        "delta": "https://cdn.tanglebay.com/snapshots/iota-mainnet/delta_snapshot.bin"
+      }      
     ]
   },
   "pruning": {

--- a/stardust/config_mainnet.json
+++ b/stardust/config_mainnet.json
@@ -74,7 +74,9 @@
       "enabled": true,
       "entryNodes": [
         "/dns/entry-hornet-0.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/K4cHM64KxzYJ5ZB2a9P3stJUHjvQDh4bzhCw49xDowi",
-        "/dns/entry-hornet-1.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/8UbVu5MjRZH2c9fnEdpfPvd7qqDgrVFsNsvc933FuMTm"
+        "/dns/entry-hornet-1.h.stardust-mainnet.iotaledger.net/udp/14626/autopeering/8UbVu5MjRZH2c9fnEdpfPvd7qqDgrVFsNsvc933FuMTm",
+        "/dns/entry-0.iota-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC",
+        "/dns/entry-1.iota-mainnet.tanglebay.com/udp/14626/autopeering/CATsx21mFVvQQPXeDineGs9DDeKvoBBQdzcmR6ffCkVA"
       ]
     }
   },
@@ -85,6 +87,10 @@
       {
         "full": "https://files.stardust-mainnet.iotaledger.net/snapshots/latest-full_snapshot.bin",
         "delta": "https://files.stardust-mainnet.iotaledger.net/snapshots/latest-delta_snapshot.bin"
+      },
+      {
+        "full": "https://cdn.tanglebay.com/snapshots/iota-mainnet/full_snapshot.bin",
+        "delta": "https://cdn.tanglebay.com/snapshots/iota-mainnet/delta_snapshot.bin"
       }
     ]
   }

--- a/stardust/config_shimmer.json
+++ b/stardust/config_shimmer.json
@@ -87,6 +87,10 @@
       {
         "full": "https://files.shimmer.network/snapshots/latest-full_snapshot.bin",
         "delta": "https://files.shimmer.network/snapshots/latest-delta_snapshot.bin"
+      },
+      {
+        "full": "https://cdn.tanglebay.com/snapshots/shimmer-mainnet/full_snapshot.bin",
+        "delta": "https://cdn.tanglebay.com/snapshots/shimmer-mainnet/delta_snapshot.bin"
       }
     ]
   }


### PR DESCRIPTION
After the Stardust upgrade the Tangle Bay entry nodes and snapshot sources were removed. This PR will add the sources back.