### PR TITLE
fix: Remove `accelerator` from disabled cadvisor metrics

### DIFF
--- a/iota-testnet/docker-compose.yml
+++ b/iota-testnet/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - --global_housekeeping_interval=30s
       - --event_storage_event_limit=default=0
       - --event_storage_age_limit=default=0
-      - --disable_metrics=accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
+      - --disable_metrics=advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
       - --enable_load_reader=true
       - --docker_only=true # only show stats for docker containers
       - --allow_dynamic_housekeeping=true

--- a/iota/docker-compose.yml
+++ b/iota/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - --global_housekeeping_interval=30s
       - --event_storage_event_limit=default=0
       - --event_storage_age_limit=default=0
-      - --disable_metrics=accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
+      - --disable_metrics=advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
       - --enable_load_reader=true
       - --docker_only=true # only show stats for docker containers
       - --allow_dynamic_housekeeping=true

--- a/iota2-testnet/docker-compose.yml
+++ b/iota2-testnet/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       - --global_housekeeping_interval=30s
       - --event_storage_event_limit=default=0
       - --event_storage_age_limit=default=0
-      - --disable_metrics=accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
+      - --disable_metrics=advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
       - --enable_load_reader=true
       - --docker_only=true          # only show stats for docker containers
       - --allow_dynamic_housekeeping=true

--- a/shimmer-testnet/docker-compose.yml
+++ b/shimmer-testnet/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - --global_housekeeping_interval=30s
       - --event_storage_event_limit=default=0
       - --event_storage_age_limit=default=0
-      - --disable_metrics=accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
+      - --disable_metrics=advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
       - --enable_load_reader=true
       - --docker_only=true # only show stats for docker containers
       - --allow_dynamic_housekeeping=true

--- a/shimmer/docker-compose.yml
+++ b/shimmer/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - --global_housekeeping_interval=30s
       - --event_storage_event_limit=default=0
       - --event_storage_age_limit=default=0
-      - --disable_metrics=accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
+      - --disable_metrics=advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp
       - --enable_load_reader=true
       - --docker_only=true # only show stats for docker containers
       - --allow_dynamic_housekeeping=true


### PR DESCRIPTION
Starting more recent versions of `cadvisor` with `accelerator` in `disable_metrics` causes the following error:

```
invalid value "accelerator,advtcp,cpu_topology,disk,hugetlb,memory_numa,percpu,referenced_memory,resctrl,sched,tcp,udp" for flag -disable_metrics: unsupported metric "accelerator" specified
```
It seems like this metric was removed in https://github.com/google/cadvisor/pull/3206 and https://github.com/google/cadvisor/pull/3458. 