### PR TITLE
Add Wasp access node config options

### DIFF
--- a/iota-testnet/docker-compose.yml
+++ b/iota-testnet/docker-compose.yml
@@ -337,8 +337,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
-      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
-      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
+      - "--stateManager.pruningMinStatesToKeep=${WASP_PRUNING_MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${WASP_SNAPSHOT_NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/iota-testnet/docker-compose.yml
+++ b/iota-testnet/docker-compose.yml
@@ -337,6 +337,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
+      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/iota-testnet/env_template
+++ b/iota-testnet/env_template
@@ -70,6 +70,16 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
+##############################
+# Wasp configuration section #
+##############################
+
+# Choose how many state to keep
+# MIN_STATES_TO_KEEP=10000
+
+# Path to download snapshot from
+# NETWORK_PATHS=https://files.iota-testnet.iotaledger.net/?prefix=wasp_snapshots/tst1pzxsrr7apqkdzz633dyntmvxwtyvk029p39te5j0m33q6946h7akzv663zu/
+
 #####################
 # Dashboard section #
 #####################

--- a/iota-testnet/env_template
+++ b/iota-testnet/env_template
@@ -70,16 +70,6 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
-##############################
-# Wasp configuration section #
-##############################
-
-# Choose how many state to keep
-# MIN_STATES_TO_KEEP=10000
-
-# Path to download snapshot from
-# NETWORK_PATHS=https://files.iota-testnet.iotaledger.net/?prefix=wasp_snapshots/tst1pzxsrr7apqkdzz633dyntmvxwtyvk029p39te5j0m33q6946h7akzv663zu/
-
 #####################
 # Dashboard section #
 #####################
@@ -91,3 +81,13 @@
 #   docker compose run hornet tools pwd-hash
 #DASHBOARD_PASSWORD=0000000000000000000000000000000000000000000000000000000000000000
 #DASHBOARD_SALT=0000000000000000000000000000000000000000000000000000000000000000
+
+################
+# WASP section #
+################
+
+# Choose how many states to keep
+#WASP_PRUNING_MIN_STATES_TO_KEEP=10000
+
+# Path to download wasp snapshot from
+#WASP_SNAPSHOT_NETWORK_PATHS=https://files.iota-testnet.iotaledger.net/?prefix=wasp_snapshots/tst1pzxsrr7apqkdzz633dyntmvxwtyvk029p39te5j0m33q6946h7akzv663zu/

--- a/iota/docker-compose.yml
+++ b/iota/docker-compose.yml
@@ -336,8 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
-      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
-      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
+      - "--stateManager.pruningMinStatesToKeep=${WASP_PRUNING_MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${WASP_SNAPSHOT_NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/iota/docker-compose.yml
+++ b/iota/docker-compose.yml
@@ -336,6 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
+      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/iota/env_template
+++ b/iota/env_template
@@ -70,16 +70,6 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
-##############################
-# Wasp configuration section #
-##############################
-
-# Choose how many state to keep
-# MIN_STATES_TO_KEEP=10000
-
-# Path to download snapshot from
-# NETWORK_PATHS=https://files.stardust-mainnet.iotaledger.net/?prefix=wasp_snapshots/iota1pzt3mstq6khgc3tl0mwuzk3eqddkryqnpdxmk4nr25re2466uxwm28qqxu5/
-
 #####################
 # Dashboard section #
 #####################
@@ -91,3 +81,13 @@
 #   docker compose run hornet tools pwd-hash
 #DASHBOARD_PASSWORD=0000000000000000000000000000000000000000000000000000000000000000
 #DASHBOARD_SALT=0000000000000000000000000000000000000000000000000000000000000000
+
+################
+# WASP section #
+################
+
+# Choose how many states to keep
+#WASP_PRUNING_MIN_STATES_TO_KEEP=10000
+
+# Path to download wasp snapshot from
+#WASP_SNAPSHOT_NETWORK_PATHS=https://files.stardust-mainnet.iotaledger.net/?prefix=wasp_snapshots/iota1pzt3mstq6khgc3tl0mwuzk3eqddkryqnpdxmk4nr25re2466uxwm28qqxu5/

--- a/iota/env_template
+++ b/iota/env_template
@@ -70,6 +70,16 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
+##############################
+# Wasp configuration section #
+##############################
+
+# Choose how many state to keep
+# MIN_STATES_TO_KEEP=10000
+
+# Path to download snapshot from
+# NETWORK_PATHS=https://files.stardust-mainnet.iotaledger.net/?prefix=wasp_snapshots/iota1pzt3mstq6khgc3tl0mwuzk3eqddkryqnpdxmk4nr25re2466uxwm28qqxu5/
+
 #####################
 # Dashboard section #
 #####################

--- a/shimmer-testnet/docker-compose.yml
+++ b/shimmer-testnet/docker-compose.yml
@@ -336,8 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
-      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
-      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
+      - "--stateManager.pruningMinStatesToKeep=${WASP_PRUNING_MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${WASP_SNAPSHOT_NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/shimmer-testnet/docker-compose.yml
+++ b/shimmer-testnet/docker-compose.yml
@@ -336,6 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
+      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/shimmer-testnet/env_template
+++ b/shimmer-testnet/env_template
@@ -70,6 +70,16 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
+##############################
+# Wasp configuration section #
+##############################
+
+# Choose how many state to keep
+# MIN_STATES_TO_KEEP=10000
+
+# Path to download snapshot from
+# NETWORK_PATHS=https://files.testnet.shimmer.network/wasp_snapshots
+
 #####################
 # Dashboard section #
 #####################

--- a/shimmer-testnet/env_template
+++ b/shimmer-testnet/env_template
@@ -70,16 +70,6 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
-##############################
-# Wasp configuration section #
-##############################
-
-# Choose how many state to keep
-# MIN_STATES_TO_KEEP=10000
-
-# Path to download snapshot from
-# NETWORK_PATHS=https://files.testnet.shimmer.network/wasp_snapshots
-
 #####################
 # Dashboard section #
 #####################
@@ -91,3 +81,13 @@
 #   docker compose run hornet tools pwd-hash
 #DASHBOARD_PASSWORD=0000000000000000000000000000000000000000000000000000000000000000
 #DASHBOARD_SALT=0000000000000000000000000000000000000000000000000000000000000000
+
+################
+# WASP section #
+################
+
+# Choose how many states to keep
+#WASP_PRUNING_MIN_STATES_TO_KEEP=10000
+
+# Path to download wasp snapshot from
+#WASP_SNAPSHOT_NETWORK_PATHS=https://files.testnet.shimmer.network/wasp_snapshots

--- a/shimmer/docker-compose.yml
+++ b/shimmer/docker-compose.yml
@@ -336,8 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
-      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
-      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
+      - "--stateManager.pruningMinStatesToKeep=${WASP_PRUNING_MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${WASP_SNAPSHOT_NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/shimmer/docker-compose.yml
+++ b/shimmer/docker-compose.yml
@@ -336,6 +336,8 @@ services:
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
       - "--users=/app/waspdb/users.json"
+      - "--stateManager.pruningMinStatesToKeep=${MIN_STATES_TO_KEEP:-10000}"
+      - "--snapshots.networkPaths=${NETWORK_PATHS:-[]}"
     profiles:
       - wasp
 

--- a/shimmer/env_template
+++ b/shimmer/env_template
@@ -70,6 +70,16 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
+##############################
+# Wasp configuration section #
+##############################
+
+# Choose how many state to keep
+# MIN_STATES_TO_KEEP=10000
+
+# Path to download snapshot from
+# NETWORK_PATHS=https://files.shimmer.shimmer.network/wasp_snapshots
+
 #####################
 # Dashboard section #
 #####################

--- a/shimmer/env_template
+++ b/shimmer/env_template
@@ -70,16 +70,6 @@
 # WASP Dashboard will be available under <NODE_HOST>/wasp/dashboard
 #COMPOSE_PROFILES=${COMPOSE_PROFILES},wasp
 
-##############################
-# Wasp configuration section #
-##############################
-
-# Choose how many state to keep
-# MIN_STATES_TO_KEEP=10000
-
-# Path to download snapshot from
-# NETWORK_PATHS=https://files.shimmer.shimmer.network/wasp_snapshots
-
 #####################
 # Dashboard section #
 #####################
@@ -91,3 +81,13 @@
 #   docker compose run hornet tools pwd-hash
 #DASHBOARD_PASSWORD=0000000000000000000000000000000000000000000000000000000000000000
 #DASHBOARD_SALT=0000000000000000000000000000000000000000000000000000000000000000
+
+################
+# WASP section #
+################
+
+# Choose how many states to keep
+#WASP_PRUNING_MIN_STATES_TO_KEEP=10000
+
+# Path to download wasp snapshot from
+#WASP_SNAPSHOT_NETWORK_PATHS=https://files.shimmer.shimmer.network/wasp_snapshots


### PR DESCRIPTION
I didn't like the current method of having to edit the docker-compose file manually so I moved these options to the env file.
As most wasp operators will be access node operators I think this is a valid path to go.

We could also add the snapshot path as set to our url by default as most people will probably use that functionality.
What do you think?